### PR TITLE
persisting cart after login (saved in db) works

### DIFF
--- a/backend/config/userDataHandler.php
+++ b/backend/config/userDataHandler.php
@@ -38,13 +38,33 @@ class UserDataHandler {
         $stmt->execute([':email' => $data['email']]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        // Falls User existiert, passwort prüfen
         if ($user && password_verify($data['password'], $user['password'])) {
-            // Session starten und User-Daten merken
             if (session_status() == PHP_SESSION_NONE) { session_start(); }
+
             $_SESSION['user_id'] = $user['user_id'];
             $_SESSION['role'] = $user['role'];
             $_SESSION['firstname'] = $user['firstname'];
+
+            // --- NEU: Warenkorb-Synchronisation ---
+            $dbCart = $this->loadCartFromDb($user['user_id']);
+
+            if (!isset($_SESSION['cart'])) {
+                $_SESSION['cart'] = [];
+            }
+
+            // Merge: DB-Warenkorb in die aktuelle Session laden
+            foreach ($dbCart as $pid => $qty) {
+                if (isset($_SESSION['cart'][$pid])) {
+                    // Wenn Produkt schon im Gast-Warenkorb, Mengen addieren
+                    $_SESSION['cart'][$pid] += $qty;
+                } else {
+                    $_SESSION['cart'][$pid] = $qty;
+                }
+            }
+
+            // Den nun kombinierten Warenkorb sofort wieder in der DB sichern
+            $this->saveCartToDb($user['user_id'], $_SESSION['cart']);
+            // --------------------------------------
 
             return [
                 "success" => true,
@@ -52,7 +72,6 @@ class UserDataHandler {
                 "user" => ["id" => $user['user_id'], "role" => $user['role']]
             ];
         }
-
         return ["success" => false, "message" => "E-Mail oder Passwort falsch."];
     }
 
@@ -67,8 +86,14 @@ class UserDataHandler {
         return ["isAdmin" => false];
     }
 
-    public function logoutUser()
-    {
+    public function logoutUser() {
+        if (session_status() == PHP_SESSION_NONE) { session_start(); }
+
+        // Falls ein User eingeloggt ist, Warenkorb in DB retten
+        if (isset($_SESSION['user_id']) && isset($_SESSION['cart'])) {
+            $this->saveCartToDb($_SESSION['user_id'], $_SESSION['cart']);
+        }
+
         $_SESSION = [];
         session_destroy();
         return ["success" => true, "message" => "Logout erfolgreich!"];
@@ -82,5 +107,41 @@ class UserDataHandler {
             return ["loggedIn" => true, "role" => $_SESSION['role'],"firstname" => $_SESSION['firstname']];
         }
         return ["loggedIn" => false];
+    }
+
+    //user x cart functions
+
+    private function saveCartToDb($userId, $cartData) {
+        // 1. Zuerst alles löschen, was dieser User aktuell in der DB hat
+        $deleteSql = "DELETE FROM shopping_cart WHERE user_id = :uid";
+        $deleteStmt = $this->db->prepare($deleteSql);
+        $deleteStmt->execute([':uid' => $userId]);
+
+        // 2. Wenn die Session leer ist (alle Produkte gelöscht), sind wir hier fertig
+        if (empty($cartData)) {
+            return;
+        }
+
+        // 3. Jetzt den aktuellen Stand aus der Session speichern
+        $insertSql = "INSERT INTO shopping_cart (user_id, product_id, quantity)
+                      VALUES (:uid, :pid, :qty)";
+        $insertStmt = $this->db->prepare($insertSql);
+
+        foreach ($cartData as $productId => $quantity) {
+            $insertStmt->execute([
+                ':uid' => $userId,
+                ':pid' => $productId,
+                ':qty' => $quantity
+            ]);
+        }
+    }
+
+    private function loadCartFromDb($userId) {
+        $sql = "SELECT product_id, quantity FROM shopping_cart WHERE user_id = :uid";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([':uid' => $userId]);
+
+        // Gibt ein Array zurück: [productId => quantity, ...]
+        return $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
     }
 }

--- a/backend/services/debugSession.php
+++ b/backend/services/debugSession.php
@@ -1,0 +1,12 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+$debug = [
+    "session_id" => session_id(),
+    "session_status" => session_status(), // 2 bedeutet aktiv
+    "data" => $_SESSION,
+    "cookie_name" => session_name()
+];
+
+echo json_encode($debug, JSON_PRETTY_PRINT);


### PR DESCRIPTION
You can call new file debugSession in your browser to current session items, might be helpful.

ADD THIS TO YOUR DB!!!:

CREATE TABLE IF NOT EXISTS shopping_cart (
    cart_id INT AUTO_INCREMENT PRIMARY KEY,
    user_id INT NOT NULL,
    product_id INT NOT NULL,
    quantity INT NOT NULL,
    UNIQUE KEY unique_user_product (user_id, product_id)
);

Implemented a session debugging page to provide real-time visibility into PHP session states and cart contents. Integrated cart persistence by saving session data to the database during logout and restoring it upon login. Added a merging logic during the login process to combine existing guest items with the user's saved database records. Refined the logout handler to ensure the current cart state is fully synchronized with the database before the session is destroyed.