### PR TITLE
US 2.7: Implement customer order detail view

### DIFF
--- a/backend/services/orderLogic.php
+++ b/backend/services/orderLogic.php
@@ -154,7 +154,7 @@ class OrderLogic
         }
         //get Order Details & return
         $result = $this->orderDataHandler->getOrderById($orderId);
-        if (!$result['order'] || $result['order']['user_id'] !== $_SESSION['user_id']) {
+        if (!$result['order'] || (int)$result['order']['user_id'] !== (int)$_SESSION['user_id']) {
             return ["error" => "unauthorized"];
         }
         return ["success" => true, "data" => $result];

--- a/frontend/assets/js/orderDetails.js
+++ b/frontend/assets/js/orderDetails.js
@@ -1,0 +1,202 @@
+$(document).ready(function () {
+    const params = new URLSearchParams(window.location.search);
+    const orderId = params.get("order_id");
+
+    if (!orderId) {
+        showOrderMessage("No order selected.", "warning");
+        return;
+    }
+
+    loadOrderDetails(orderId);
+
+    $("#btnPrintInvoice").click(function () {
+        window.open("invoice.html?order_id=" + orderId, "_blank");
+    });
+});
+
+function loadOrderDetails(orderId) {
+    $.ajax({
+        type: "GET",
+        url: "../../backend/services/orderServiceHandler.php",
+        cache: false,
+        data: {
+            method: "getOrderById",
+            order_id: orderId
+        },
+        dataType: "json",
+
+        success: function (response) {
+            console.log(response);
+
+            if (response.error === "not_logged_in") {
+                showOrderMessage("Please log in to view this order.", "warning");
+                return;
+            }
+
+            if (response.error === "unauthorized") {
+                showOrderMessage("You are not allowed to view this order.", "danger");
+                return;
+            }
+
+            if (response.error === "missing_order_id") {
+                showOrderMessage("No order selected.", "warning");
+                return;
+            }
+
+            if (response.success) {
+                displayOrderDetails(response.data);
+            } else {
+                showOrderMessage("Order details could not be loaded.", "danger");
+            }
+        },
+
+        error: function (xhr) {
+            console.error("Order detail loading error:", xhr.responseText);
+            showOrderMessage("Error connecting to the server.", "danger");
+        }
+    });
+}
+
+function displayOrderDetails(data) {
+    const order = data.order;
+    const items = data.items;
+
+    $("#orderDetailMessage").empty();
+    $("#orderDetailWrapper").removeClass("d-none");
+
+    $("#orderId").text("#" + order.id);
+    $("#orderDate").text(formatOrderDate(order.created_at));
+    $("#orderStatus").html(getStatusBadge(order.status));
+    $("#customerName").text(order.firstname + " " + order.lastname);
+
+    let tableBody = $("#orderItemsTableBody");
+    tableBody.empty();
+
+    if (!items || items.length === 0) {
+        tableBody.html(`
+            <tr>
+                <td colspan="4" class="text-center">
+                    No items found for this order.
+                </td>
+            </tr>
+        `);
+    } else {
+        items.forEach(function (item) {
+            let unitPrice = parseFloat(item.unit_price).toFixed(2);
+            let total = parseFloat(item.total).toFixed(2);
+
+            let row = `
+                <tr>
+                    <td>${escapeHtml(item.product_name)}</td>
+                    <td>${item.quantity}</td>
+                    <td>${unitPrice} €</td>
+                    <td>${total} €</td>
+                </tr>
+            `;
+
+            tableBody.append(row);
+        });
+    }
+
+    $("#orderSubtotal").text(parseFloat(order.subtotal).toFixed(2) + " €");
+    $("#orderTax").text(parseFloat(order.tax_amount).toFixed(2) + " €");
+    $("#orderTotal").text(parseFloat(order.total).toFixed(2) + " €");
+}
+
+function showOrderMessage(message, type) {
+    $("#orderDetailWrapper").addClass("d-none");
+
+    $("#orderDetailMessage").html(`
+        <div class="alert alert-${type}">
+            ${message}
+        </div>
+    `);
+}
+
+function formatOrderDate(dateString) {
+    if (!dateString) {
+        return "-";
+    }
+
+    let datePart = dateString.substring(0, 10);
+    let parts = datePart.split("-");
+
+    if (parts.length !== 3) {
+        return dateString;
+    }
+
+    return parts[2] + "." + parts[1] + "." + parts[0];
+}
+
+function getStatusBadge(status) {
+    let statusInfo;
+
+    switch (status) {
+        case "pending":
+            statusInfo = {
+                text: "Pending",
+                badgeClass: "bg-warning"
+            };
+            break;
+
+        case "processing":
+            statusInfo = {
+                text: "Processing",
+                badgeClass: "bg-info"
+            };
+            break;
+
+        case "shipped":
+            statusInfo = {
+                text: "Shipped",
+                badgeClass: "bg-primary"
+            };
+            break;
+
+        case "delivered":
+            statusInfo = {
+                text: "Delivered",
+                badgeClass: "bg-success"
+            };
+            break;
+
+        case "cancelled":
+            statusInfo = {
+                text: "Cancelled",
+                badgeClass: "bg-danger"
+            };
+            break;
+
+        case "refunded":
+            statusInfo = {
+                text: "Refunded",
+                badgeClass: "bg-secondary"
+            };
+            break;
+
+        default:
+            statusInfo = {
+                text: status,
+                badgeClass: "bg-dark"
+            };
+    }
+
+    return `
+        <span class="badge ${statusInfo.badgeClass}">
+            ${statusInfo.text}
+        </span>
+    `;
+}
+
+function escapeHtml(text) {
+    if (!text) {
+        return "";
+    }
+
+    return String(text)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+}

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -3,6 +3,15 @@ $(document).ready(function () {
 
     loadUserProfile();
 
+    const params = new URLSearchParams(window.location.search);
+    const activeTab = params.get("tab");
+
+    if (activeTab === "orders") {
+        resetProfileFormToSavedData()
+        showMyOrdersTab();
+        loadOrders();
+    }
+
     // Tab-Wechsel zwsichen Profildaten und Bestellungen
     $(document).on("click", "#tabPersonalInfo", function (e) {
         e.preventDefault();
@@ -11,7 +20,7 @@ $(document).ready(function () {
 
     $(document).on("click", "#tabMyOrders", function (e) {
         e.preventDefault();
-        switchToViewMode();
+        resetProfileFormToSavedData()
         showMyOrdersTab();
 
         loadOrders();
@@ -122,8 +131,7 @@ $(document).ready(function () {
     });
 
     $("#btnCancelEdit").click(function () {
-        switchToViewMode();
-        fillFormFields(currentProfileData);
+        resetProfileFormToSavedData();
     });
 
     $("#paymentMethod").change(function () {
@@ -159,6 +167,16 @@ $(document).ready(function () {
 
         $("#btnToggleEdit").removeClass("d-none");
     }
+
+    //Verhindert, dass nicht gespeicherte Daten in den Feldern bleiben
+    function resetProfileFormToSavedData() {
+        if (currentProfileData) {
+            fillFormFields(currentProfileData);
+        }
+
+        switchToViewMode();
+    }
+
 
     // Submit Form
     $("#profileForm").submit(function (e) {
@@ -309,9 +327,8 @@ $(document).ready(function () {
                 </td>
                 <td>
                     <div class="d-flex gap-2 justify-content-start">
-                        <button class="btn btn-outline-primary btn-sm"
-                                data-order-id="${order.id}"
-                                disabled>
+                        <button class="btn btn-outline-primary btn-sm btn-view-order"
+                                data-order-id="${order.id}">
                             View Details
                         </button>
 
@@ -393,5 +410,10 @@ $(document).ready(function () {
     $(document).on("click", ".btn-print-invoice", function () {
         let orderId = $(this).data("order-id");
         window.open("invoice.html?order_id=" + orderId, "_blank");
+    });
+
+    $(document).on("click", ".btn-view-order", function () {
+        let orderId = $(this).data("order-id");
+        window.location.href = "orderDetails.html?order_id=" + orderId;
     });
 });

--- a/frontend/pages/orderDetails.html
+++ b/frontend/pages/orderDetails.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="../components/header.js"></script>
+    <title>Order Details</title>
+</head>
+<body>
+
+<div class="container mt-5">
+    <h2 class="mb-4">Order Details</h2>
+
+    <div id="orderDetailMessage"></div>
+
+    <div id="orderDetailWrapper" class="d-none">
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title">Order Information</h5>
+
+                <p><strong>Order ID:</strong> <span id="orderId"></span></p>
+                <p><strong>Date:</strong> <span id="orderDate"></span></p>
+                <p><strong>Status:</strong> <span id="orderStatus"></span></p>
+                <p><strong>Customer:</strong> <span id="customerName"></span></p>
+            </div>
+        </div>
+
+        <h4>Purchased Items</h4>
+
+        <div class="table-responsive">
+            <table class="table table-bordered align-middle">
+                <thead>
+                <tr>
+                    <th>Product</th>
+                    <th>Quantity</th>
+                    <th>Unit price</th>
+                    <th>Total</th>
+                </tr>
+                </thead>
+                <tbody id="orderItemsTableBody"></tbody>
+            </table>
+        </div>
+
+        <div class="text-end">
+            <p><strong>Subtotal incl. VAT:</strong> <span id="orderSubtotal"></span></p>
+            <p><strong>Included VAT (20%):</strong> <span id="orderTax"></span></p>
+            <h4><strong>Total: </strong><span id="orderTotal"></span></h4>
+        </div>
+
+        <div class="mt-4 d-flex gap-2">
+            <a href="profile.html?tab=orders" class="btn btn-secondary">Back to profile</a>
+            <button id="btnPrintInvoice" class="btn btn-outline-secondary">Print Invoice</button>
+        </div>
+    </div>
+</div>
+
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="../components/navbar.js"></script>
+<script src="../assets/js/authGuard.js"></script>
+<script src="../assets/js/orderDetails.js"></script>
+<script> requireLogin(); </script>
+
+</body>
+</html>


### PR DESCRIPTION
Order detail functionality was added.

Customers can now open a specific order from the "My Orders" section in their profile. When clicking the "View Details" button, the user is redirected to a separate order detail page. This page displays all purchased items of the selected order, including product name, quantity, unit price and total price.

The backend loads the order details by using the order ID. Before the details are returned, the system checks whether the selected order belongs to the currently logged-in user. This prevents users from accessing orders of other customers by manually changing the order ID in the URL.

The navigation was also improved. When the user returns from the order detail page back to the profile page, the "My Orders" tab is opened automatically instead of the "Personal Information" tab.

Additionally, a small bug was fixed where unsaved changes in the personal information form remained visible after switching between profile tabs. The form now resets to the last saved profile data when switching to the "My Orders" tab.

Please check if everything works on your machine. 