### PR TITLE
feat: add product edit and delete functionality for admin

### DIFF
--- a/backend/config/productDataHandler.php
+++ b/backend/config/productDataHandler.php
@@ -115,6 +115,88 @@ class ProductDataHandler {
         }
     }
 
+    public function updateProduct($id, $productData, $imageFile) {
+        $name        = trim($productData["name"] ?? "");
+        $description = trim($productData["description"] ?? "");
+        $price       = trim($productData["price"] ?? "");
+        $category    = trim($productData["category"] ?? "");
+        $rating      = trim($productData["rating"] ?? "");
+
+        if ($name === "" || $description === "" || $price === "" || $category === "" || $rating === "") {
+            return ["success" => false, "message" => "Please fill all fields."];
+        }
+
+        if (!is_numeric($price) || (float)$price < 0) {
+            return ["success" => false, "message" => "Invalid price."];
+        }
+
+        if (!is_numeric($rating) || (int)$rating < 1 || (int)$rating > 5) {
+            return ["success" => false, "message" => "Rating must be between 1 and 5."];
+        }
+
+        try {
+            // Neues Bild nur wenn hochgeladen
+            $newFileName = null;
+            if ($imageFile && isset($imageFile["error"]) && $imageFile["error"] === UPLOAD_ERR_OK) {
+                $allowedExtensions = ["jpg", "jpeg", "png", "webp"];
+                $fileExtension = strtolower(pathinfo($imageFile["name"], PATHINFO_EXTENSION));
+
+                if (!in_array($fileExtension, $allowedExtensions)) {
+                    return ["success" => false, "message" => "Only JPG, JPEG, PNG or WEBP allowed."];
+                }
+
+                $uploadDir = dirname(__DIR__) . "/productpictures/";
+                $newFileName = uniqid("product_", true) . "." . $fileExtension;
+                $targetPath = $uploadDir . $newFileName;
+
+                if (!move_uploaded_file($imageFile["tmp_name"], $targetPath)) {
+                    return ["success" => false, "message" => "Image could not be saved."];
+                }
+            }
+
+            // SQL dynamisch – Bild nur updaten wenn neues hochgeladen
+            $sql = "UPDATE products SET
+                    name        = :name,
+                    description = :description,
+                    price       = :price,
+                    category    = :category,
+                    rating      = :rating
+                    " . ($newFileName ? ", image = :image" : "") . "
+                WHERE product_id = :id";
+
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindValue(":name",        $name);
+            $stmt->bindValue(":description", $description);
+            $stmt->bindValue(":price",       (float)$price);
+            $stmt->bindValue(":category",    $category);
+            $stmt->bindValue(":rating",      (int)$rating, PDO::PARAM_INT);
+            $stmt->bindValue(":id",          (int)$id, PDO::PARAM_INT);
+
+            if ($newFileName) {
+                $stmt->bindValue(":image", $newFileName);
+            }
+
+            if ($stmt->execute()) {
+                return ["success" => true, "message" => "Product updated successfully."];
+            }
+
+            return ["success" => false, "message" => "Product could not be updated."];
+
+        } catch (PDOException $e) {
+            return ["success" => false, "message" => "DB-Error: " . $e->getMessage()];
+        }
+    }
+
+    public function deleteProduct($id) {
+        try {
+            $stmt = $this->db->prepare("DELETE FROM products WHERE product_id = :id");
+            $stmt->execute([':id' => $id]);
+            return ["success" => true, "message" => "Product deleted successfully."];
+        } catch (PDOException $e) {
+            return ["success" => false, "message" => "DB-Error: " . $e->getMessage()];
+        }
+    }
+
     public function searchProducts($query){
         $sql = "SELECT * FROM products WHERE name LIKE :query";
         $stmt = $this->db->prepare($sql);

--- a/backend/services/productLogic.php
+++ b/backend/services/productLogic.php
@@ -13,6 +13,9 @@ class ProductLogic {
             case "getAllProducts":
                 return $this->dh->getAllProducts();
 
+            case "getProductById":
+                return $this->dh->getProductById($data["product_id"] ?? null);
+
             case "createProduct":
                 return $this->dh->createProduct($data, $files["image"] ?? null);
 
@@ -24,6 +27,12 @@ class ProductLogic {
 
             case "searchProducts":
                 return $this->dh->searchProducts($data["query"] ?? "");
+
+            case "updateProduct":
+                return $this->dh->updateProduct($data["product_id"], $data, $files["image"] ?? null);
+
+            case "deleteProduct":
+                return $this->dh->deleteProduct($data["product_id"] ?? null);
 
             default:
                 return ["success" => false, "message" => "Method not allowed"];

--- a/frontend/assets/js/admin.js
+++ b/frontend/assets/js/admin.js
@@ -234,4 +234,93 @@ $(document).ready(function () {
         });
     });
 
+    //Delete Product
+    $(document).on("click", ".btn-delete", function () {
+        let productId = $(this).data("id");
+
+        if (confirm("Are you sure you want to delete this product?")) {
+            $.ajax({
+                type: "POST",
+                url: "../../backend/services/productServiceHandler.php",
+                data: { method: "deleteProduct", product_id: productId },
+                dataType: "json",
+                success: function (response) {
+                    if (response.success) {
+                        loadProducts();
+                    } else {
+                        alert(response.message);
+                    }
+                },
+                error: function (xhr) {
+                    console.error("Error deleting product:", xhr.responseText);
+                }
+            });
+        }
+    });
+
+    //Edit Product lädt Daten von db und öffnet Modal
+    $(document).on("click", ".btn-edit", function () {
+        let productId = $(this).data("id");
+        $.ajax({
+            type: "POST",
+            url: "../../backend/services/productServiceHandler.php",
+            data: { method: "getProductById", product_id: productId },
+            dataType: "json",
+            success: function (product) {
+                console.log(product);
+                $("#editProductId").val(product.product_id);
+                $("#editProductName").val(product.name);
+                $("#editProductDescription").val(product.description);
+                $("#editProductPrice").val(product.price);
+                $("#editProductCategory").val(product.category);
+                $("#editProductRating").val(product.rating);
+
+                // Modal öffnen
+                let modal = new bootstrap.Modal(document.getElementById("editProductModal"));
+                modal.show();
+            },
+            error: function (xhr) {
+                console.error("Error loading product:", xhr.responseText);
+            }
+        });
+    });
+
+    //Save Changes in edit Product Modul
+    $("#btnSaveProduct").on("click", function () {
+        let formData = new FormData();
+        formData.append("method", "updateProduct");
+        formData.append("product_id", $("#editProductId").val());
+        formData.append("name", $("#editProductName").val());
+        formData.append("description", $("#editProductDescription").val());
+        formData.append("price", $("#editProductPrice").val());
+        formData.append("category", $("#editProductCategory").val());
+        formData.append("rating", $("#editProductRating").val());
+
+        // Bild nur anhängen wenn eines ausgewählt wurde
+        let imageFile = $("#editProductImage")[0].files[0];
+        if (imageFile) {
+            formData.append("image", imageFile);
+        }
+
+        $.ajax({
+            type: "POST",
+            url: "../../backend/services/productServiceHandler.php",
+            data: formData,
+            processData: false,
+            contentType: false,
+            dataType: "json",
+            success: function (response) {
+                if (response.success) {
+                    bootstrap.Modal.getInstance(document.getElementById("editProductModal")).hide();
+                    loadProducts();
+                } else {
+                    alert(response.message);
+                }
+            },
+            error: function (xhr) {
+                console.error("Error updating product:", xhr.responseText);
+            }
+        });
+    });
+
 });

--- a/frontend/pages/admin.html
+++ b/frontend/pages/admin.html
@@ -113,6 +113,56 @@
     </div>
 </div>
 
+<div class="modal fade" id="editProductModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Edit Product</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="editProductForm" enctype="multipart/form-data">
+                    <input type="hidden" id="editProductId">
+                    <div class="mb-3">
+                        <label class="form-label">Product Name</label>
+                        <input type="text" class="form-control" id="editProductName" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Description</label>
+                        <textarea class="form-control" id="editProductDescription" rows="3" required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Price</label>
+                        <input type="number" class="form-control" id="editProductPrice" step="0.01" min="0" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Category</label>
+                        <select class="form-control" id="editProductCategory" required>
+                            <option value="Supplements">Supplements</option>
+                            <option value="Clothing">Clothing</option>
+                            <option value="Equipment">Equipment</option>
+                            <option value="Accessories">Accessories</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Rating (1-5)</label>
+                        <input type="number" class="form-control" id="editProductRating" min="1" max="5" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Product Image (optional)</label>
+                        <input type="file" class="form-control" id="editProductImage" accept=".jpg,.jpeg,.png,.webp">
+                        <small class="text-muted">Leave empty to keep current image.</small>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="btnSaveProduct">Save Changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="../assets/js/admin.js"></script>


### PR DESCRIPTION
Admins can now edit and delete products directly from the product list. Clicking Edit opens a modal pre-filled with the current product data — name, description, price, category, rating and image can all be updated. The image is only replaced if a new one is uploaded. Clicking Delete asks for confirmation before permanently removing the product from the database. The product list refreshes automatically after both actions. Added updateProduct() and deleteProduct() to productDataHandler.php, the corresponding cases in productLogic.php, and click handlers in admin.js. requireAdmin() was also added to productServiceHandler.php as a security guard. please test if it works on your machine.