### PR TITLE
US 3.11 - Add remove product functionality for customer orders

### DIFF
--- a/backend/config/orderDataHandler.php
+++ b/backend/config/orderDataHandler.php
@@ -72,7 +72,7 @@ class OrderDataHandler {
         $order->execute([':order_id' => $order_id]);
         $order = $order->fetch(PDO::FETCH_ASSOC);
         //get products
-        $items = $this->db->prepare("SELECT * FROM order_items WHERE order_id = :order_id");
+        $items = $this->db->prepare("SELECT id AS order_item_id, order_id, product_id, product_name, quantity, unit_price, total FROM order_items WHERE order_id = :order_id");
         $items->execute([':order_id' => $order_id]);
         $items = $items->fetchAll(PDO::FETCH_ASSOC);
         return [
@@ -95,16 +95,7 @@ class OrderDataHandler {
         }
 
         try {
-            $stmt = $this->db->prepare("
-                SELECT
-                    id,
-                    status,
-                    total,
-                    created_at
-                FROM orders
-                WHERE user_id = :user_id
-                ORDER BY created_at DESC
-            ");
+            $stmt = $this->db->prepare("SELECT id, status, total, created_at FROM orders WHERE user_id = :user_id ORDER BY created_at DESC");
 
             $stmt->execute([
                 ':user_id' => $data['userId']
@@ -142,6 +133,101 @@ class OrderDataHandler {
             return ["success" => true, "data" => $orderDetails];
 
         } catch (PDOException $e) {
+            return ["success" => false, "message" => "Database error: " . $e->getMessage()];
+        }
+    }
+
+    public function removeOrderItemFromOrder($data) {
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+            return ["success" => false, "message" => "Unauthorized access. Admins only."];
+        }
+
+        if (!isset($data['orderId']) || !isset($data['orderItemId'])) {
+            return ["success" => false, "message" => "Missing order ID or order item ID."];
+        }
+
+        $orderId = $data['orderId'];
+        $orderItemId = $data['orderItemId'];
+
+        try {
+            $this->db->beginTransaction();
+            $checkStmt = $this->db->prepare("SELECT total FROM order_items WHERE id = :order_item_id AND order_id = :order_id");
+
+            $checkStmt->execute([
+                ':order_item_id' => $orderItemId,
+                ':order_id' => $orderId
+            ]);
+
+            $item = $checkStmt->fetch(PDO::FETCH_ASSOC);
+
+            if (!$item) {
+                $this->db->rollBack();
+                return ["success" => false, "message" => "Order item not found."];
+            }
+
+            $deleteStmt = $this->db->prepare("DELETE FROM order_items WHERE id = :order_item_id AND order_id = :order_id");
+
+            $deleteStmt->execute([
+                ':order_item_id' => $orderItemId,
+                ':order_id' => $orderId
+            ]);
+
+            $sumStmt = $this->db->prepare("SELECT COUNT(*) AS remaining_items, COALESCE(SUM(total), 0) AS new_subtotal FROM order_items WHERE order_id = :order_id");
+
+            $sumStmt->execute([
+                ':order_id' => $orderId
+            ]);
+
+            $sumResult = $sumStmt->fetch(PDO::FETCH_ASSOC);
+            $remainingItems = (int)$sumResult['remaining_items'];
+            $newSubtotal = (float)$sumResult['new_subtotal'];
+
+            $orderStmt = $this->db->prepare("SELECT discount_amount FROM orders WHERE id = :order_id");
+
+            $orderStmt->execute([
+                ':order_id' => $orderId
+            ]);
+
+            $order = $orderStmt->fetch(PDO::FETCH_ASSOC);
+            $discountAmount = $order ? (float)$order['discount_amount'] : 0;
+
+            if ($remainingItems === 0) {
+                $discountAmount = 0;
+            }
+
+            if ($discountAmount > $newSubtotal) {
+                $discountAmount = $newSubtotal;
+            }
+
+            $newTotal = $newSubtotal - $discountAmount;
+
+            // VAT is included in the total price: 20 / 120
+            $newTaxAmount = $newTotal * 20 / 120;
+
+            $updateStmt = $this->db->prepare("UPDATE orders SET subtotal = :subtotal, tax_amount = :tax_amount, total = :total, discount_amount = :discount_amount, status = CASE WHEN :remaining_items = 0 THEN 'cancelled' ELSE status END WHERE id = :order_id");
+            $updateStmt->execute([
+                ':subtotal' => number_format($newSubtotal, 2, '.', ''),
+                ':tax_amount' => number_format($newTaxAmount, 2, '.', ''),
+                ':total' => number_format($newTotal, 2, '.', ''),
+                ':discount_amount' => number_format($discountAmount, 2, '.', ''),
+                ':remaining_items' => $remainingItems,
+                ':order_id' => $orderId
+            ]);
+
+            $this->db->commit();
+
+            if ($remainingItems === 0) {
+                return ["success" => true, "message" => "Product was removed. The order has no products left and was cancelled."];
+            }
+
+            return ["success" => true, "message" => "Product was removed from the order."];
+
+        } catch (PDOException $e) {
+            $this->db->rollBack();
             return ["success" => false, "message" => "Database error: " . $e->getMessage()];
         }
     }

--- a/backend/services/orderLogic.php
+++ b/backend/services/orderLogic.php
@@ -29,6 +29,8 @@ class OrderLogic
                 return $this->orderDataHandler->getOrdersByCustomerForAdmin($data);
             case "getOrderDetailsForAdmin":
                 return $this->orderDataHandler->getOrderDetailsForAdmin($data);
+           case "removeOrderItemFromOrder":
+               return $this->orderDataHandler->removeOrderItemFromOrder($data);
             default:
                 return ["error" => "Unknown method"];
         }

--- a/frontend/assets/js/admin.js
+++ b/frontend/assets/js/admin.js
@@ -3,6 +3,7 @@ $(document).ready(function () {
     // Prüffunktion beim Laden der Seite
     requireAdmin();
     loadProducts();
+    let currentCustomerId = null;
     $("body").show();
 
     // Switch zu Add Product
@@ -259,6 +260,7 @@ $(document).ready(function () {
 // Event-Handler für View Orders
     $(document).on("click", ".btn-view-orders", function () {
         let userId = $(this).data("id");
+        currentCustomerId = userId;
         let customerName = $(this).closest("tr").find("td").eq(2).text();
 
         $("#customerListView").hide();
@@ -397,6 +399,7 @@ $(document).ready(function () {
                                 <th>Quantity</th>
                                 <th>Unit price</th>
                                 <th>Total</th>
+                                <th class="text-end">Action</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -409,6 +412,14 @@ $(document).ready(function () {
                             <td>${item.quantity}</td>
                             <td>${parseFloat(item.unit_price).toFixed(2)} €</td>
                             <td>${parseFloat(item.total).toFixed(2)} €</td>
+                            <td class="text-end">
+                                <button 
+                                    class="btn btn-sm btn-outline-danger btn-remove-order-item"
+                                    data-order-id="${order.id}"
+                                    data-item-id="${item.order_item_id}">
+                                    Remove
+                                </button>
+                            </td>
                         </tr>
                     `;
                     });
@@ -431,6 +442,44 @@ $(document).ready(function () {
 
             error: function (xhr) {
                 console.error("Error loading order details:", xhr.responseText);
+            }
+        });
+    });
+
+    //Remove-Click-Handler
+    $(document).on("click", ".btn-remove-order-item", function () {
+        let orderId = $(this).data("order-id");
+        let orderItemId = $(this).data("item-id");
+
+        if (!confirm("Are you sure you want to remove this product from the order?")) {
+            return;
+        }
+
+        $.ajax({
+            type: "POST",
+            url: "../../backend/services/orderServiceHandler.php",
+            data: {
+                method: "removeOrderItemFromOrder",
+                orderId: orderId,
+                orderItemId: orderItemId
+            },
+            dataType: "json",
+
+            success: function (response) {
+                if (response.success) {
+                    $(".btn-view-order-detail[data-id='" + orderId + "']").click();
+
+                    if (currentCustomerId) {
+                        loadCustomerOrders(currentCustomerId);
+                    }
+                } else {
+                    alert(response.message);
+                }
+            },
+
+            error: function (xhr) {
+                console.error("Error removing order item:", xhr.responseText);
+                alert("Error connecting to the server.");
             }
         });
     });


### PR DESCRIPTION
Admins can now open a customer's order details and remove individual products from the order. The selected product is deleted from the order items in the database and the order details are updated immediately.

After a product is removed, the order subtotal, included VAT and total amount are recalculated based on the remaining products. The updated values are shown in the admin order detail view and are also reflected in the customer's order details.

If all products are removed from an order, the order total is set to 0.00 and the order status is automatically changed to cancelled. This prevents empty orders from staying active.

Removed products are no longer visible to the customer because the customer order detail page loads the products directly from the updated order items table.

Please check if everything works on your machine.