### PR TITLE
Add product detail page

### DIFF
--- a/frontend/assets/js/index.js
+++ b/frontend/assets/js/index.js
@@ -16,7 +16,8 @@ $(document).ready(function () {
     });
 
     // Produkt in den Warenkorb legen
-    $(document).on("click", ".btn-add-cart", function () {
+    $(document).on("click", ".btn-add-cart", function (event) {
+        event.stopPropagation();
         let productId = $(this).data("id");
 
         $.ajax({
@@ -32,8 +33,6 @@ $(document).ready(function () {
                 if (typeof window.refreshCartBadge === "function") {
                     window.refreshCartBadge();
                 }
-
-                console.log("Products were added to the basket.");
             },
 
             error: function (xhr) {
@@ -155,7 +154,6 @@ $(document).ready(function () {
             dataType: "json",
 
             success: function (products) {
-                console.log("Loaded products:", products);
                 renderProducts(products);
             },
 
@@ -197,7 +195,7 @@ $(document).ready(function () {
 
             let productCard = `
                 <div class="col-md-4 mb-4">
-                    <div class="card h-100">
+                    <div class="card h-100 product-card" data-id="${product.product_id}" style="cursor: pointer;">
                         <img src="${imageSrc}" class="card-img-top" alt="${escapeHtml(product.name)}">
 
                         <div class="card-body">
@@ -231,6 +229,12 @@ $(document).ready(function () {
             container.append(productCard);
         });
     }
+
+    // Öffnet die Produktdetailseite beim Klick auf eine Produktkarte
+    $(document).on("click", ".product-card", function () {
+        let productId = $(this).data("id");
+        window.location.href = `pages/productDetails.html?product_id=${productId}`;
+    });
 
     // Verhindert, dass Sonderzeichen oder HTML im Produktnamen die Seite kaputt machen
     function escapeHtml(text) {

--- a/frontend/assets/js/productDetails.js
+++ b/frontend/assets/js/productDetails.js
@@ -1,0 +1,143 @@
+$(document).ready(function () {
+    loadProductDetails();
+
+    $(document).on("click", ".btn-add-cart", function () {
+        let productId = $(this).data("id");
+
+        $.ajax({
+            type: "POST",
+            url: "../../backend/services/cartServiceHandler.php",
+            data: {
+                method: "addToCart",
+                productId: productId
+            },
+            dataType: "json",
+
+            success: function () {
+                if (typeof window.refreshCartBadge === "function") {
+                    window.refreshCartBadge();
+                }
+
+            },
+
+            error: function (xhr) {
+                console.error("Error when adding to basket:", xhr.responseText);
+            }
+        });
+    });
+});
+
+function loadProductDetails() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const productId = urlParams.get("product_id");
+
+    if (!productId) {
+        $("#productDetailsContainer").html(`
+            <div class="alert alert-danger">
+                No product selected.
+            </div>
+        `);
+        return;
+    }
+
+    $.ajax({
+        type: "GET",
+        url: "../../backend/services/productServiceHandler.php",
+        data: {
+            method: "getProductById",
+            product_id: productId
+        },
+        dataType: "json",
+
+        success: function (product) {
+            if (!product || !product.product_id) {
+                $("#productDetailsContainer").html(`
+                    <div class="alert alert-danger">
+                        Product could not be found.
+                    </div>
+                `);
+                return;
+            }
+
+            renderProductDetails(product);
+        },
+
+        error: function (xhr) {
+            console.error("Error when loading product details:", xhr.responseText);
+
+            $("#productDetailsContainer").html(`
+                <div class="alert alert-danger">
+                    Error when loading product details.
+                </div>
+            `);
+        }
+    });
+}
+
+function renderProductDetails(product) {
+    let imageSrc = "https://via.placeholder.com/300";
+
+    if (product.image) {
+        imageSrc = `../../backend/productpictures/${product.image}`;
+    }
+
+    let ratingHtml = "";
+
+    if (product.rating) {
+        ratingHtml = `<p>Rating: ${escapeHtml(product.rating)} / 5</p>`;
+    }
+
+    let price = Number(product.price).toFixed(2);
+
+    let description = escapeHtml(product.description).replaceAll("\n", "<br>");
+
+    let html = `
+        <div class="row">
+            <div class="col-md-5 text-center">
+                <img src="${imageSrc}"
+                     class="img-fluid rounded"
+                     style="max-height: 450px; max-width: 100%; object-fit: contain;"
+                     alt="${escapeHtml(product.name)}">
+            </div>
+
+            <div class="col-md-7">
+                <h2>${escapeHtml(product.name)}</h2>
+
+                <p class="text-muted">
+                    Category: ${escapeHtml(product.category)}
+                </p>
+
+                ${ratingHtml}
+
+                <h4 class="fw-bold">
+                    ${price} €
+                </h4>
+
+                <hr>
+
+                <h5>Description</h5>
+                <p>${description}</p>
+
+                <button class="btn btn-outline-primary btn-add-cart"
+                        data-id="${product.product_id}">
+                    Add to basket
+                </button>
+            </div>
+        </div>
+    `;
+
+    $("#productDetailsContainer").html(html);
+}
+
+function escapeHtml(text) {
+    if (text === null || text === undefined) {
+        return "";
+    }
+
+    return String(text)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+}

--- a/frontend/pages/productDetails.html
+++ b/frontend/pages/productDetails.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <title>Product Details</title>
+  <script src="../components/header.js"></script>
+  <meta charset="UTF-8">
+</head>
+<body>
+
+<div class="container mt-5">
+  <div id="productDetailsContainer">
+    <div class="text-center">Loading product...</div>
+  </div>
+
+  <a href="../index.html" class="btn btn-secondary mt-4">Back to products</a>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="../components/navbar.js"></script>
+<script src="../assets/js/productDetails.js?v=1"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Users can now click on a product card on the homepage and are redirected to a separate product detail page. The detail page loads the selected product by using the product ID from the URL.
The homepage still only displays a shortened product description, while the product detail page shows the full description and all relevant product information such as image, name, category, rating and price.
Please check if everything works on your machine.