### PR TITLE
Bugfix/payment methods

### DIFF
--- a/backend/config/userDataHandler.php
+++ b/backend/config/userDataHandler.php
@@ -371,6 +371,8 @@ class UserDataHandler {
         return ["success" => false, "message" => "Failed to update profile."];
     }
 
+    // Updates existing additional payment methods and inserts newly added ones.
+    // New methods are detected by the temporary frontend id "new".
     private function updateAdditionalPaymentMethods($userData) {
         if (!isset($userData['additionalPaymentMethods']) || !is_array($userData['additionalPaymentMethods'])) {
             return ["success" => true];
@@ -378,14 +380,55 @@ class UserDataHandler {
 
         $seenMethods = [];
         foreach ($userData['additionalPaymentMethods'] as $paymentMethodData) {
-            $paymentId = (int)($paymentMethodData['id'] ?? 0);
+        // Existing payment methods have a numeric database id.
+        // Newly added rows are sent with the temporary id "new".
+            $rawPaymentId = $paymentMethodData['id'] ?? 0;
+            $isNewPaymentMethod = ($rawPaymentId === 'new');
+            $paymentId = $isNewPaymentMethod ? 0 : (int)$rawPaymentId;
             $method = trim($paymentMethodData['paymentMethod'] ?? '');
             $details = trim($paymentMethodData['details'] ?? '');
 
-            if ($paymentId <= 0 || !in_array($method, ['invoice', 'creditcard'], true)) {
+            if (!$isNewPaymentMethod && $paymentId <= 0) {
                 return ["success" => false, "message" => "Invalid additional payment method."];
             }
 
+            if (!in_array($method, ['invoice', 'creditcard'], true)) {
+                return ["success" => false, "message" => "Invalid additional payment method."];
+            }
+
+            // Insert newly added payment methods after validating required fields and duplicates.
+            if ($isNewPaymentMethod) {
+                if ($method === 'creditcard' && empty($details)) {
+                    return ["success" => false, "message" => "Please enter your credit card number."];
+                }
+
+                $finalDetails = $method === 'creditcard'
+                    ? $this->normalizePaymentDetails($method, $details)
+                    : null;
+
+                if ($this->paymentMethodExists($_SESSION['user_id'], $method, $finalDetails)) {
+                    return ["success" => false, "message" => "This payment method already exists on your account."];
+                }
+
+                if ($this->defaultPaymentMethodExists($_SESSION['user_id'], $method, $finalDetails)) {
+                    return ["success" => false, "message" => "This payment method already exists on your account."];
+                }
+
+                $insertStmt = $this->db->prepare(
+                    "INSERT INTO payment_methods (user_id, method, details, is_default)
+                     VALUES (:uid, :method, :details, 0)"
+                );
+
+                $insertStmt->execute([
+                    ':uid' => $_SESSION['user_id'],
+                    ':method' => $method,
+                    ':details' => $finalDetails
+                ]);
+
+                continue;
+            }
+
+            // Existing payment methods must belong to the logged-in user before they can be updated.
             $currentStmt = $this->db->prepare(
                 "SELECT method, details FROM payment_methods WHERE id = :id AND user_id = :uid"
             );
@@ -443,6 +486,7 @@ class UserDataHandler {
         return ["success" => true];
     }
 
+    // Normalizes credit card details before duplicate checks.
     private function normalizePaymentDetails($method, $details) {
         if ($method !== 'creditcard') {
             return null;
@@ -455,6 +499,7 @@ class UserDataHandler {
         return $method . ':' . ($this->normalizePaymentDetails($method, $details) ?? '');
     }
 
+    // Checks whether the same additional payment method already exists for this user.
     private function paymentMethodExists($userId, $method, $details, $excludePaymentId = null) {
         $normalizedDetails = $this->normalizePaymentDetails($method, $details);
         $sql = "SELECT id, details FROM payment_methods
@@ -483,6 +528,7 @@ class UserDataHandler {
         return false;
     }
 
+    // Prevents saving an additional payment method that already exists as the user's default method.
     private function defaultPaymentMethodExists($userId, $method, $details) {
         $normalizedDetails = $this->normalizePaymentDetails($method, $details);
         $stmt = $this->db->prepare(
@@ -650,7 +696,8 @@ class UserDataHandler {
             }
         }
 
-        //Get all methods of current user
+        // Loads all additional payment methods of the logged-in user.
+        // Credit card details are masked before they are sent to the frontend.
         public function getPaymentMethods() {
             if (session_status() == PHP_SESSION_NONE) { session_start(); }
             if (!isset($_SESSION['user_id'])) {
@@ -678,51 +725,16 @@ class UserDataHandler {
             }
         }
 
-        //Add Payment Methods to Database
-        public function addPaymentMethod($data) {
-            if (session_status() == PHP_SESSION_NONE) { session_start(); }
-            if (!isset($_SESSION['user_id'])) {
-                return ["success" => false, "message" => "Unauthorized."];
-            }
-
-            $method  = trim($data['paymentMethod']  ?? '');
-            $details = trim($data['details'] ?? '');
-
-            if (empty($method)) {
-                return ["success" => false, "message" => "Please select a payment method."];
-            }
-            if ($method === 'creditcard' && empty($details)) {
-                return ["success" => false, "message" => "Please enter your credit card number."];
-            }
-
-            try {
-                $normalizedDetails = $this->normalizePaymentDetails($method, $details);
-                if (
-                    $this->paymentMethodExists($_SESSION['user_id'], $method, $normalizedDetails) ||
-                    $this->defaultPaymentMethodExists($_SESSION['user_id'], $method, $normalizedDetails)
-                ) {
-                    return ["success" => false, "message" => "This payment method already exists on your account."];
-                }
-
-                $stmt = $this->db->prepare(
-                    "INSERT INTO payment_methods (user_id, method, details, is_default) 
-                 VALUES (:uid, :method, :details, 0)"
-                );
-                $stmt->execute([
-                    ':uid'     => $_SESSION['user_id'],
-                    ':method'  => $method,
-                    ':details' => $normalizedDetails,
-                ]);
-                return ["success" => true, "message" => "Payment method added successfully!"];
-            } catch (PDOException $e) {
-                return ["success" => false, "message" => "DB Error: " . $e->getMessage()];
-            }
-        }
-
+        // Deletes an additional payment method of the logged-in user.
+        // The current password is checked server-side because frontend checks can be bypassed.
         public function deletePaymentMethod($data) {
             if (session_status() == PHP_SESSION_NONE) { session_start(); }
             if (!isset($_SESSION['user_id'])) {
                 return ["success" => false, "message" => "Unauthorized."];
+            }
+
+            if (!$this->verifyCurrentPassword($data['passwordConfirm'] ?? '')) {
+                return ["success" => false, "message" => "Confirmation failed. Current password incorrect."];
             }
 
             $paymentId = (int)($data['paymentId'] ?? 0);
@@ -786,5 +798,18 @@ class UserDataHandler {
             error_log("Error deducting user balance: " . $e->getMessage());
             return false;
         }
+    }
+
+    // Verifies the current password before sensitive account changes are executed.
+    private function verifyCurrentPassword($passwordConfirm) {
+        if (empty(trim($passwordConfirm ?? ''))) {
+            return false;
+        }
+
+        $stmt = $this->db->prepare("SELECT password FROM users WHERE user_id = :uid");
+        $stmt->execute([':uid' => $_SESSION['user_id']]);
+        $passwordHash = $stmt->fetchColumn();
+
+        return $passwordHash && password_verify($passwordConfirm, $passwordHash);
     }
 }

--- a/backend/services/userLogic.php
+++ b/backend/services/userLogic.php
@@ -32,8 +32,6 @@ class UserLogic {
                  return $this->userDataHandler->getUserDetailsForAdmin($data);
             case "getPaymentMethods":
                 return $this->userDataHandler->getPaymentMethods();
-            case "addPaymentMethod":
-                return $this->userDataHandler->addPaymentMethod($data);
             case "deletePaymentMethod":
                 return $this->userDataHandler->deletePaymentMethod($data);
             default:

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -265,8 +265,8 @@ $(document).ready(function () {
         }
     }
 
-    // Enables editing for already saved additional payment methods.
-    // Existing credit card numbers are not shown again and can be replaced by entering a new number.
+    // Collects existing and newly added payment methods for the profile save request.
+    // Newly added rows are sent with the temporary payment id "new".
     function collectAdditionalPaymentMethods() {
         let paymentMethods = [];
 
@@ -647,7 +647,7 @@ $(document).ready(function () {
         let detailsId = "additionalPaymentDetailsNew" + index;
 
         container.append(`
-        <div class="row mb-3 g-2 additional-payment-row" data-is-new="1">
+        <div class="row mb-3 g-2 additional-payment-row">
             <div class="col-md-5">
                 <label for="${methodId}" class="form-label">Additional Payment Method</label>
                 <select class="form-select additional-payment-method"

--- a/frontend/assets/js/profile.js
+++ b/frontend/assets/js/profile.js
@@ -1,6 +1,10 @@
 $(document).ready(function () {
     let currentProfileData = null;
 
+    // Zentraler Status für den Profil-Bearbeitungsmodus.
+    // Dieser Status gilt für alle Profiländerungen, also auch für zusätzliche Zahlungsmethoden.
+    let profileEditMode = false;
+
     loadUserProfile();
 
     const params = new URLSearchParams(window.location.search);
@@ -22,7 +26,6 @@ $(document).ready(function () {
         e.preventDefault();
         resetProfileFormToSavedData()
         showMyOrdersTab();
-
         loadOrders();
     });
 
@@ -36,6 +39,8 @@ $(document).ready(function () {
 
         $("#btnToggleEdit").removeClass("d-none");
         $("#profileMessage").addClass("d-none");
+
+        updatePaymentActionButtons();
     }
 
     function showMyOrdersTab() {
@@ -66,6 +71,7 @@ $(document).ready(function () {
                 if (response.success) {
                     currentProfileData = response.data;
                     fillFormFields(currentProfileData);
+                    updatePaymentActionButtons();
                 } else {
                     showMessage(response.message, "danger");
                 }
@@ -112,10 +118,12 @@ $(document).ready(function () {
         return maskCreditCard(cardNumber);
     }
 
-    // Edit Profile Clicked
-    $("#btnToggleEdit").click(function () {
-        $("#profileForm").find('input, select').prop('disabled', false);
+    // Enables editing for profile data and payment methods.
+    // Existing credit card numbers are cleared in the input fields so they are not exposed.
+    function enterProfileEditMode() {
+        profileEditMode = true;
 
+        $("#profileForm").find('input, select').prop('disabled', false);
         $("#balance").prop('disabled', true);
 
         if ($("#paymentMethod").val() === "creditcard") {
@@ -137,8 +145,51 @@ $(document).ready(function () {
         $("#confirmNewPassword").val('');
         $("#passwordConfirm").prop('required', true).val('');
 
-        $(this).addClass("d-none");
+        $("#btnToggleEdit").addClass("d-none");
         $("#profileMessage").addClass("d-none");
+
+        updatePaymentActionButtons();
+    }
+
+    // Deaktiviert den Bearbeitungsmodus und setzt die Ansicht zurück.
+    function exitProfileEditMode() {
+        profileEditMode = false;
+
+        $("#profileForm").find("input, select").prop("disabled", true);
+        $("#paymentDetails").attr("placeholder", "");
+
+        setAdditionalPaymentViewMode();
+
+        // Sicherstellen, dass das Guthaben-Feld immer gesperrt bleibt
+        $("#balance").prop("disabled", true);
+
+        // Tausche echte Eingabefelder wieder zurück gegen die Attrappe
+        $("#passwordChangeGroup").attr("style", "display: none !important;");
+        $("#dummyPasswordGroup").attr("style", "display: block !important;");
+
+        // Verstecke Kontrollbereiche
+        $("#actionButtons").attr("style", "display: none !important;");
+        $("#passwordConfirmGroup").attr("style", "display: none !important;");
+
+        $("#newPassword").val("");
+        $("#confirmNewPassword").val("");
+        $("#passwordConfirm").prop("required", false).val("");
+
+        $("#btnToggleEdit").removeClass("d-none");
+
+        updatePaymentActionButtons();
+    }
+
+    // Zeigt oder versteckt Add/Delete Buttons für zusätzliche Zahlungsmethoden.
+    // Wichtig: Delete-Buttons werden dynamisch erzeugt, daher wird diese Funktion nach jedem Laden der Zahlungsmethoden aufgerufen.
+    function updatePaymentActionButtons() {
+        $("#btnAddPaymentMethod").toggleClass("d-none", !profileEditMode);
+        $(".btn-delete-payment-method").toggleClass("d-none", !profileEditMode);
+    }
+
+    // Edit Profile Clicked
+    $("#btnToggleEdit").click(function () {
+        enterProfileEditMode();
     });
 
     $("#btnCancelEdit").click(function () {
@@ -147,10 +198,14 @@ $(document).ready(function () {
 
     $("#paymentMethod").change(function () {
         toggleCreditCardDisplay($(this).val());
-        if ($(this).val() === "creditcard" && !$(this).is(':disabled')) {
-            $("#paymentDetails").attr("placeholder", "Enter card number").prop('required', true);
+
+        if ($(this).val() === "creditcard" && !$(this).is(":disabled")) {
+            $("#paymentDetails")
+                .attr("placeholder", "Enter card number")
+                .prop("required", true);
         }
     });
+
 
     function toggleCreditCardDisplay(method) {
         if (method === "creditcard") {
@@ -160,6 +215,8 @@ $(document).ready(function () {
         }
     }
 
+    // Enables editing for already saved additional payment methods.
+    // Existing credit card numbers are not shown again and can be replaced by entering a new number.
     function enableAdditionalPaymentEditMode() {
         $(".additional-payment-method").prop('disabled', false);
         $(".additional-payment-details")
@@ -171,6 +228,8 @@ $(document).ready(function () {
         });
     }
 
+    // Restores the read-only view for additional payment methods.
+    // Credit card details are shown only as masked placeholders.
     function setAdditionalPaymentViewMode() {
         $(".additional-payment-method").prop('disabled', true);
         $(".additional-payment-details")
@@ -206,6 +265,8 @@ $(document).ready(function () {
         }
     }
 
+    // Enables editing for already saved additional payment methods.
+    // Existing credit card numbers are not shown again and can be replaced by entering a new number.
     function collectAdditionalPaymentMethods() {
         let paymentMethods = [];
 
@@ -224,26 +285,7 @@ $(document).ready(function () {
     }
 
     function switchToViewMode() {
-        $("#profileForm").find('input, select').prop('disabled', true);
-        $("#paymentDetails").attr("placeholder", "");
-        setAdditionalPaymentViewMode();
-
-        //Sicherstellen, dass das Guthaben-Feld immer gesperrt bleibt
-        $("#balance").prop('disabled', true);
-
-        // Tausche echte Eingabefelder wieder zurück gegen die Attrappe
-        $("#passwordChangeGroup").attr("style", "display: none !important;");
-        $("#dummyPasswordGroup").attr("style", "display: block !important;");
-
-        // Verstecke Kontrollbereiche
-        $("#actionButtons").attr("style", "display: none !important;");
-        $("#passwordConfirmGroup").attr("style", "display: none !important;");
-
-        $("#newPassword").val('');
-        $("#confirmNewPassword").val('');
-        $("#passwordConfirm").prop('required', false).val('');
-
-        $("#btnToggleEdit").removeClass("d-none");
+        exitProfileEditMode();
     }
 
     //Verhindert, dass nicht gespeicherte Daten in den Feldern bleiben
@@ -253,6 +295,9 @@ $(document).ready(function () {
         }
 
         switchToViewMode();
+
+        // Entfernt auch neu hinzugefügte, aber nicht gespeicherte Payment-Method-Zeilen.
+        loadAdditionalPaymentMethods();
     }
 
 
@@ -296,9 +341,9 @@ $(document).ready(function () {
             success: function (response) {
                 if (response.success) {
                     showMessage(response.message, "success");
+                    switchToViewMode();
                     loadUserProfile();
                     loadAdditionalPaymentMethods();
-                    switchToViewMode();
                 } else {
                     showMessage(response.message, "danger");
                     $("#passwordConfirm").val('').focus();
@@ -336,7 +381,6 @@ $(document).ready(function () {
             dataType: "json",
 
             success: function (response) {
-                console.log(response);
 
                 if (response.error === "not_logged_in") {
                     $("#ordersTableWrapper").addClass("d-none");
@@ -425,68 +469,6 @@ $(document).ready(function () {
         });
     }
 
-    // Hilfsfunktionen für Bestelldatum
-    function formatOrderDate(dateString) {
-        if (!dateString) {
-            return "-";
-        }
-
-        let datePart = dateString.substring(0, 10);
-        let parts = datePart.split("-");
-
-        if (parts.length !== 3) {
-            return dateString;
-        }
-
-        return parts[2] + "." + parts[1] + "." + parts[0];
-    }
-
-    // Hilfsfunktion für Bestellstatus
-    function getStatusInfo(status) {
-        switch (status) {
-            case "pending":
-                return {
-                    text: "Pending",
-                    badgeClass: "bg-warning"
-                };
-
-            case "processing":
-                return {
-                    text: "Processing",
-                    badgeClass: "bg-info"
-                };
-
-            case "shipped":
-                return {
-                    text: "Shipped",
-                    badgeClass: "bg-primary"
-                };
-
-            case "delivered":
-                return {
-                    text: "Delivered",
-                    badgeClass: "bg-success"
-                };
-
-            case "cancelled":
-                return {
-                    text: "Cancelled",
-                    badgeClass: "bg-danger"
-                };
-
-            case "refunded":
-                return {
-                    text: "Refunded",
-                    badgeClass: "bg-secondary"
-                };
-
-            default:
-                return {
-                    text: status,
-                    badgeClass: "bg-dark"
-                };
-        }
-    }
     $(document).on("click", ".btn-print-invoice", function () {
         let orderId = $(this).data("order-id");
         window.open("invoice.html?order_id=" + orderId, "_blank");
@@ -497,9 +479,18 @@ $(document).ready(function () {
         window.location.href = "orderDetails.html?order_id=" + orderId;
     });
 
-    //Add Payment
-    loadAdditionalPaymentMethods();
 
+
+
+    //      PAYMENT METHODS
+
+    // Zusätzliche Zahlungsmethoden laden.
+    // Danach wird sichergestellt, dass Add/Delete im View Mode nicht sichtbar sind.
+    loadAdditionalPaymentMethods();
+    updatePaymentActionButtons();
+
+    // Loads all additional payment methods of the logged-in user.
+    // The default payment method is loaded separately from the user profile.
     function loadAdditionalPaymentMethods() {
         $.ajax({
             type: "POST",
@@ -508,20 +499,25 @@ $(document).ready(function () {
             data: { method: "getPaymentMethods" },
             dataType: "json",
             success: function (response) {
-                if (!response.success) return;
+                if (!response.success) {
+                    updatePaymentActionButtons()
+                    return;
+                }
 
                 let container = $("#additionalPaymentMethodsList");
                 container.empty();
 
-                // Nur nicht-default anzeigen (default ist schon oben sichtbar)
-                let extras = response.data.filter(p => p.is_default == 0);
+                // Alle Methoden, die vom Backend kommen, sind zusätzliche Zahlungsmethoden.
+                // Die Default-Methode steht bereits oben im Profil und kommt aus der users-Tabelle.
+                let paymentMethods = response.data;
 
-                if (extras.length === 0) {
+                if (!paymentMethods || paymentMethods.length === 0) {
                     container.html('<p class="text-muted small mb-0">No additional payment methods saved.</p>');
+                    updatePaymentActionButtons();
                     return;
                 }
 
-                extras.forEach(function (pm, index) {
+                paymentMethods.forEach(function (pm, index) {
                     let details = pm.method === 'creditcard'
                         ? getMaskedCreditCardDisplay(pm.details)
                         : '';
@@ -530,26 +526,43 @@ $(document).ready(function () {
                     let cardColumnStyle = pm.method === 'creditcard' ? '' : ' style="display:none;"';
 
                     container.append(`
-                        <div class="row mb-3 g-2 additional-payment-row">
-                            <div class="col-md-5">
-                                <label for="${methodId}" class="form-label">Additional Payment Method</label>
-                                <select class="form-select additional-payment-method" id="${methodId}" data-payment-id="${pm.id}" data-original-method="${pm.method}" disabled>
-                                    <option value="invoice" ${pm.method === 'invoice' ? 'selected' : ''}>Invoice</option>
-                                    <option value="creditcard" ${pm.method === 'creditcard' ? 'selected' : ''}>Credit Card</option>
-                                </select>
-                            </div>
-                            <div class="col-md-5 additional-card-group"${cardColumnStyle}>
-                                <label for="${detailsId}" class="form-label">Credit Card Number</label>
-                                <input type="text" class="form-control additional-payment-details" id="${detailsId}" value="${escapeHtml(details)}" disabled>
-                            </div>
-                            <div class="col-auto d-flex align-items-end">
-                                <button type="button" class="btn btn-outline-danger btn-sm btn-delete-payment-method" data-payment-id="${pm.id}">
-                                    Delete
-                                </button>
-                            </div>
+                    <div class="row mb-3 g-2 additional-payment-row">
+                        <div class="col-md-5">
+                            <label for="${methodId}" class="form-label">Additional Payment Method</label>
+                            <select class="form-select additional-payment-method"
+                                    id="${methodId}"
+                                    data-payment-id="${pm.id}"
+                                    data-original-method="${pm.method}"
+                                    disabled>
+                                <option value="invoice" ${pm.method === "invoice" ? "selected" : ""}>Invoice</option>
+                                <option value="creditcard" ${pm.method === "creditcard" ? "selected" : ""}>Credit Card</option>
+                            </select>
                         </div>
-                    `);
+
+                        <div class="col-md-5 additional-card-group"${cardColumnStyle}>
+                            <label for="${detailsId}" class="form-label">Credit Card Number</label>
+                            <input type="text"
+                                   class="form-control additional-payment-details"
+                                   id="${detailsId}"
+                                   value="${escapeHtml(details)}"
+                                   disabled>
+                        </div>
+
+                        <div class="col-auto d-flex align-items-end">
+                            <button type="button"
+                                    class="btn btn-outline-danger btn-sm btn-delete-payment-method d-none"
+                                    data-payment-id="${pm.id}">
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                `);
                 });
+
+                updatePaymentActionButtons();
+            },
+            error: function () {
+                updatePaymentActionButtons();
             }
         });
     }
@@ -564,37 +577,38 @@ $(document).ready(function () {
     }
 
     $("#btnAddPaymentMethod").click(function () {
-        $("#addPaymentMethodForm").show();
-        $("#btnAddPaymentMethod").hide();
-        $("#addPaymentMsg").hide();
-        $("#addPaymentMethodForm").find('input, select').prop('disabled', false);
-        $("#newPaymentMethodSelect").val('');
-        $("#newPaymentDetails").val('');
-        toggleNewCreditCardDisplay('');
-    });
+        // Zusätzliche Zahlungsmethoden dürfen nur im Profil-Edit-Mode hinzugefügt werden.
+        if (!profileEditMode) {
+            return;
+        }
 
-    $("#btnCancelNewPayment").click(function () {
-        $("#addPaymentMethodForm").hide();
-        $("#btnAddPaymentMethod").show();
-        $("#newPaymentMethodSelect").val('');
-        $("#newPaymentDetails").val('');
-        toggleNewCreditCardDisplay('');
-    });
-
-    $("#newPaymentMethodSelect").change(function () {
-        toggleNewCreditCardDisplay($(this).val());
+        addNewPaymentMethodRow();
     });
 
     $(document).on("change", ".additional-payment-method", function () {
         toggleAdditionalCreditCardDisplay($(this));
     });
 
+    // Deletes an existing payment method immediately.
+    // This action requires the current password and an additional confirmation dialog.
     $(document).on("click", ".btn-delete-payment-method", function () {
+        // Zusätzliche Zahlungsmethoden dürfen nur im Profil-Edit-Mode gelöscht werden.
+        if (!profileEditMode) {
+            return;
+        }
+
+        if ($("#passwordConfirm").val().trim() === "") {
+            showMessage("Please enter your current password before deleting a payment method.", "danger");
+            $("#passwordConfirm").focus();
+            return;
+        }
+
         let paymentId = $(this).data("payment-id");
 
         if (!confirm("Delete this payment method?")) {
             return;
         }
+
 
         $.ajax({
             type: "POST",
@@ -602,80 +616,77 @@ $(document).ready(function () {
             cache: false,
             data: {
                 method: "deletePaymentMethod",
-                paymentId: paymentId
+                paymentId: paymentId,
+                passwordConfirm: $("#passwordConfirm").val()
             },
             dataType: "json",
             success: function (response) {
                 if (response.success) {
-                    showAddPaymentMsg(response.message, "success");
+                    showMessage(response.message, "success");
                     loadAdditionalPaymentMethods();
                 } else {
-                    showAddPaymentMsg(response.message, "danger");
+                    showMessage(response.message, "danger");
                 }
             },
             error: function () {
-                showAddPaymentMsg("Server error.", "danger");
+                showMessage("Server error.", "danger");
             }
         });
     });
 
-    function toggleNewCreditCardDisplay(method) {
-        if (method === "creditcard") {
-            $("#newCardDetailsGroup").show();
-            $("#newPaymentDetails")
-                .attr("placeholder", "Enter card number")
-                .prop('required', true);
-        } else {
-            $("#newCardDetailsGroup").hide();
-            $("#newPaymentDetails")
-                .prop('required', false)
-                .val('');
-        }
+    // Fügt eine neue, noch nicht gespeicherte Zahlungsmethode in die Profilansicht ein.
+    // Gespeichert wird sie erst über den großen "Save Changes"-Button unten.
+    function addNewPaymentMethodRow() {
+        let container = $("#additionalPaymentMethodsList");
+
+        // Falls vorher der "No additional payment methods"-Text angezeigt wurde, entfernen.
+        container.find(".text-muted").remove();
+
+        let index = $(".additional-payment-row").length;
+        let methodId = "additionalPaymentMethodNew" + index;
+        let detailsId = "additionalPaymentDetailsNew" + index;
+
+        container.append(`
+        <div class="row mb-3 g-2 additional-payment-row" data-is-new="1">
+            <div class="col-md-5">
+                <label for="${methodId}" class="form-label">Additional Payment Method</label>
+                <select class="form-select additional-payment-method"
+                        id="${methodId}"
+                        data-payment-id="new"
+                        data-original-method=""
+                        required>
+                    <option value="">-- Select --</option>
+                    <option value="invoice">Invoice</option>
+                    <option value="creditcard">Credit Card</option>
+                </select>
+            </div>
+
+            <div class="col-md-5 additional-card-group" style="display:none;">
+                <label for="${detailsId}" class="form-label">Credit Card Number</label>
+                <input type="text"
+                       class="form-control additional-payment-details"
+                       id="${detailsId}"
+                       placeholder="Enter card number">
+            </div>
+
+            <div class="col-auto d-flex align-items-end">
+                <button type="button"
+                        class="btn btn-outline-danger btn-sm btn-remove-unsaved-payment-method">
+                    Remove
+                </button>
+            </div>
+        </div>
+    `);
     }
 
-    $("#btnSaveNewPayment").click(function () {
-        let method  = $("#newPaymentMethodSelect").val();
-        let details = $("#newPaymentDetails").val().trim();
+    // Entfernt eine neu hinzugefügte, aber noch nicht gespeicherte Zahlungsmethode wieder aus der Ansicht.
+    $(document).on("click", ".btn-remove-unsaved-payment-method", function () {
+        $(this).closest(".additional-payment-row").remove();
 
-        if (!method) {
-            showAddPaymentMsg("Please select a payment method.", "danger");
-            return;
+        if ($(".additional-payment-row").length === 0) {
+            $("#additionalPaymentMethodsList").html(
+                '<p class="text-muted small mb-0">No additional payment methods saved.</p>'
+            );
         }
-        if (method === 'creditcard' && !details) {
-            showAddPaymentMsg("Please enter your card number.", "danger");
-            return;
-        }
-
-        $.ajax({
-            type: "POST",
-            url: "../../backend/services/userServiceHandler.php",
-            cache: false,
-            data: { method: "addPaymentMethod", paymentMethod: method, details: details },
-            dataType: "json",
-            success: function (response) {
-                if (response.success) {
-                    showAddPaymentMsg(response.message, "success");
-                    loadAdditionalPaymentMethods();
-                    setTimeout(function () {
-                        $("#addPaymentMethodForm").hide();
-                        $("#btnAddPaymentMethod").show();
-                        $("#addPaymentMsg").hide();
-                    }, 1500);
-                } else {
-                    showAddPaymentMsg(response.message, "danger");
-                }
-            },
-            error: function () {
-                showAddPaymentMsg("Server error.", "danger");
-            }
-        });
     });
-
-    function showAddPaymentMsg(text, type) {
-        $("#addPaymentMsg")
-            .text(text)
-            .removeClass("alert alert-danger alert-success")
-            .addClass("alert alert-" + type)
-            .show();
-    }
 });

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -96,7 +96,6 @@
                             </div>
 
                             <!-- Payment Details -->
-                            <!-- Payment Details -->
                             <h4 class="mb-3 mt-4 text-secondary">Payment Details</h4>
 
                             <!-- Default Payment (bestehend, read-only Bereich) -->
@@ -120,35 +119,11 @@
                                     <!-- wird per JS befüllt -->
                                 </div>
 
-                                <!-- Add-Button (immer sichtbar) -->
+
+                                <!-- Add-Button wird im Edit Mode per JS angezeigt -->
                                 <button type="button" id="btnAddPaymentMethod" class="btn btn-outline-secondary btn-sm mt-1">
                                     + Add Payment Method
                                 </button>
-
-                                <!-- Inline-Formular (standardmäßig versteckt) -->
-                                <div id="addPaymentMethodForm" class="mt-3 p-3 border rounded bg-light" style="display:none;">
-                                    <h6 class="mb-3">New Payment Method</h6>
-                                    <div class="row g-2 align-items-end">
-                                        <div class="col-md-4">
-                                            <label class="form-label">Method</label>
-                                            <select class="form-select form-select-sm" id="newPaymentMethodSelect">
-                                                <option value="">-- Select --</option>
-                                                <option value="invoice">Invoice</option>
-                                                <option value="creditcard">Credit Card</option>
-                                            </select>
-                                        </div>
-                                        <div class="col-md-4" id="newCardDetailsGroup" style="display:none;">
-                                            <label class="form-label">Card Number</label>
-                                            <input type="text" class="form-control form-control-sm" id="newPaymentDetails"
-                                                   placeholder="Card number">
-                                        </div>
-                                        <div class="col-auto">
-                                            <button type="button" id="btnSaveNewPayment" class="btn btn-success btn-sm">Save</button>
-                                            <button type="button" id="btnCancelNewPayment" class="btn btn-secondary btn-sm ms-1">Cancel</button>
-                                        </div>
-                                    </div>
-                                    <div id="addPaymentMsg" class="mt-2" style="display:none;"></div>
-                                </div>
                             </div>
 
                             <!-- Optische Leseattrape des Passwort felds für den Lesemodus -> keine pw-Daten übertragen!-->


### PR DESCRIPTION
Additional payment method handling was refactored in the customer profile.

Users can now manage additional payment methods directly in the profile edit mode. New payment methods are added as editable rows and are saved together with the main "Save Changes" button. Existing additional payment methods can also be edited, while credit card details remain masked and are not exposed in the frontend.

The backend profile update logic was extended so that it can update existing additional payment methods and insert newly added ones. New payment methods are detected by the temporary frontend ID "new". Duplicate checks were added to prevent saving the same payment method twice or adding a method that already exists as the default payment method.

Deleting an additional payment method is handled as an immediate action. It requires the current password and a confirmation dialog. The password is also verified server-side before the payment method is deleted.

The branch was also updated with the latest main branch changes, including the voucher, balance, order, invoice, and payment method updates. The profile payment method logic was kept compatible with the updated checkout flow.

Please test adding, editing, deleting, and using additional payment methods during checkout.